### PR TITLE
- Fixed: orientation issue on some iOS versions

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 
 <plugin xmlns="http://cordova.apache.org/ns/plugins/1.0"
            id="com.sharinglabs.SpinnerDialog"
-      version="1.3.2">
+      version="1.3.3">
 
     <name>SpinnerDialog</name>
     

--- a/src/ios/CDVSpinnerDialog.m
+++ b/src/ios/CDVSpinnerDialog.m
@@ -30,8 +30,11 @@
 
 -(CGRect)rectForView {
     UIInterfaceOrientation orientation = [[UIApplication sharedApplication] statusBarOrientation];
-    BOOL landscape = (orientation == UIInterfaceOrientationLandscapeLeft || orientation == UIInterfaceOrientationLandscapeRight);
-    if(landscape){
+    BOOL isLandscapeMode = (orientation == UIInterfaceOrientationLandscapeLeft || orientation == UIInterfaceOrientationLandscapeRight);
+    BOOL isWidthGreaterThanHeight = [[UIScreen mainScreen]bounds].size.width > [UIScreen mainScreen].bounds.size.height;
+    // If the "isLandscapeMode" and "isWidthGreaterThanHeight" are different, it means they should be switched
+    // (it looks like on some iOS versions - some or all iOS 7? - we need to check that).
+    if(isLandscapeMode != isWidthGreaterThanHeight){
         return CGRectMake( 0.0f, 0.0f, [UIScreen mainScreen].bounds.size.height, [[UIScreen mainScreen]bounds].size.width);
     }
     return CGRectMake( 0.0f, 0.0f, [[UIScreen mainScreen]bounds].size.width, [UIScreen mainScreen].bounds.size.height);


### PR DESCRIPTION
Hi I noticed an issue with the landscape orientation: the size of the spinner is incorrect. There used to be such error but it was fixed (maybe on iOS 7). I tested on iPad iOS 8 and 9 (I don't have an iOS 7 anymore) and the issue surfaced again. I updated the code to supposedly handle all situations.

Apart from that, do you wish to maintain this repo? If yes you can just merge this pull request, if no you could make the npm plugin point to my repo.
